### PR TITLE
WIP: Export struct fields for customized generators

### DIFF
--- a/lib/generator.go
+++ b/lib/generator.go
@@ -13,26 +13,34 @@ import (
 // SecurePassword provides methods for generating secure passwords and
 // checking the security requirements of passwords
 type SecurePassword struct {
-	characterTables map[string]string
-	insecurePattern []string
-	badCharacters   []string
+	CharacterTables map[string]string
+	InsecurePattern []string
+	BadCharacters   []string
 }
 
 var (
 	// ErrLengthTooLow represents an error thrown if the password will
 	// never be able match the security considerations in this package
 	ErrLengthTooLow = errors.New("Passwords with a length lower than 4 will never meet the security requirements")
+	// ErrGeneratorMissingFeatures represents an error thrown if the generator
+	// is missing a character set required for generating passwords
+	ErrGeneratorMissingFeatures = errors.New("Password generator was not initialized with all required features")
+	// DefaultGenerator contains a pre-filled generator using the libraries
+	// default values for character tables, insecure patterns and bad
+	// characters. Mostly this is the implementation to use except you do
+	// have special requirements such as a limit of special characters.
+	DefaultGenerator = NewSecurePassword()
 )
 
 // NewSecurePassword initializes a new SecurePassword generator
 func NewSecurePassword() *SecurePassword {
 	return &SecurePassword{
-		characterTables: map[string]string{
+		CharacterTables: map[string]string{
 			"numeric": "0123456789",
 			"simple":  "abcdefghijklmnopqrstuvwxyz",
 			"special": "!#$%&()*+,-_./:;=?@[]^{}~|",
 		},
-		insecurePattern: []string{
+		InsecurePattern: []string{
 			"abcdefghijklmnopqrstuvwxyz",      // Alphabet
 			"zyxwvutsrqponmlkjihgfedcba",      // Alphabet reversed
 			"01234567890",                     // Numeric increasing
@@ -40,10 +48,10 @@ func NewSecurePassword() *SecurePassword {
 			"qwertzuiopasdfghjklyxcvbnm",      // German keyboard layout
 			"mnbvcxylkjhgfdsapoiuztrewq",      // German keyboard layout reversed
 			"qwertyuiopasdfghjklzxcvbnm",      // US keyboard layout
-			"mnbvcxzlkjhgfdsapoiuytrewq",      // US keyboard layour reversed
+			"mnbvcxzlkjhgfdsapoiuytrewq",      // US keyboard layout reversed
 			"789_456_123_147_258_369_159_753", // Numpad patterns
 		},
-		badCharacters: []string{"I", "l", "0", "O", "B", "8"}, // Characters that could lead to confusion due to font
+		BadCharacters: []string{"I", "l", "0", "O", "B", "8"}, // Characters that could lead to confusion due to font
 	}
 }
 
@@ -57,20 +65,24 @@ func (s *SecurePassword) GeneratePassword(length int, special bool) (string, err
 		return "", ErrLengthTooLow
 	}
 
+	if err := s.validateGenerator(); err != nil {
+		return "", err
+	}
+
 	characterTable := strings.Join([]string{
-		s.characterTables["simple"],
-		strings.ToUpper(s.characterTables["simple"]),
-		s.characterTables["numeric"],
+		s.CharacterTables["simple"],
+		strings.ToUpper(s.CharacterTables["simple"]),
+		s.CharacterTables["numeric"],
 	}, "")
 	if special {
-		characterTable = strings.Join([]string{characterTable, s.characterTables["special"]}, "")
+		characterTable = strings.Join([]string{characterTable, s.CharacterTables["special"]}, "")
 	}
 
 	password := ""
 	rand.Seed(time.Now().UnixNano())
 	for {
 		char := string(characterTable[rand.Intn(len(characterTable))])
-		if strings.Contains(strings.Join(s.badCharacters, ""), char) {
+		if strings.Contains(strings.Join(s.BadCharacters, ""), char) {
 			continue
 		}
 
@@ -103,7 +115,7 @@ func (s *SecurePassword) CheckPasswordSecurity(password string, needsSpecialChar
 func (s *SecurePassword) hasInsecurePattern(password string) bool {
 	for i := 0; i < len(password)-3; i++ {
 		slice := password[i : i+3] // Extract an 3 char slice to check
-		for _, pattern := range s.insecurePattern {
+		for _, pattern := range s.InsecurePattern {
 			if strings.Contains(pattern, slice) {
 				return true
 			}
@@ -149,4 +161,20 @@ func (s *SecurePassword) hasCharacterRepetition(password string) bool {
 		}
 	}
 	return false
+}
+
+func (s *SecurePassword) validateGenerator() error {
+	if _, ok := s.CharacterTables["numeric"]; !ok {
+		return ErrGeneratorMissingFeatures
+	}
+
+	if _, ok := s.CharacterTables["simple"]; !ok {
+		return ErrGeneratorMissingFeatures
+	}
+
+	if _, ok := s.CharacterTables["special"]; !ok {
+		return ErrGeneratorMissingFeatures
+	}
+
+	return nil
 }

--- a/lib/generator_test.go
+++ b/lib/generator_test.go
@@ -1,8 +1,11 @@
-package securepassword
+package securepassword_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
+
+	securepassword "github.com/Luzifer/password/lib"
 )
 
 func TestInsecurePasswords(t *testing.T) {
@@ -29,7 +32,7 @@ func TestInsecurePasswords(t *testing.T) {
 	}
 
 	for password, errorMessage := range passwords {
-		if NewSecurePassword().CheckPasswordSecurity(password, false) {
+		if securepassword.DefaultGenerator.CheckPasswordSecurity(password, false) {
 			t.Error(errorMessage)
 		}
 	}
@@ -45,7 +48,7 @@ func TestSecurePasswords(t *testing.T) {
 	}
 
 	for _, password := range passwords {
-		if !NewSecurePassword().CheckPasswordSecurity(password, false) {
+		if !securepassword.DefaultGenerator.CheckPasswordSecurity(password, false) {
 			t.Errorf("Password was rejected: %s", password)
 		}
 	}
@@ -61,7 +64,7 @@ func TestPasswordWithoutSpecialCharaterFail(t *testing.T) {
 	}
 
 	for _, password := range passwords {
-		if NewSecurePassword().CheckPasswordSecurity(password, true) {
+		if securepassword.DefaultGenerator.CheckPasswordSecurity(password, true) {
 			t.Errorf("Password was accepted: %s", password)
 		}
 	}
@@ -77,46 +80,46 @@ func TestSecurePasswordWithSpecialCharacter(t *testing.T) {
 	}
 
 	for _, password := range passwords {
-		if !NewSecurePassword().CheckPasswordSecurity(password, true) {
+		if !securepassword.DefaultGenerator.CheckPasswordSecurity(password, true) {
 			t.Errorf("Password was rejected: %s", password)
 		}
 	}
 }
 
 func TestPasswordGeneration(t *testing.T) {
-	password, _ := NewSecurePassword().GeneratePassword(20, false)
+	password, _ := securepassword.DefaultGenerator.GeneratePassword(20, false)
 
 	if len(password) != 20 {
 		t.Error("Password did not match requested length")
 	}
 
-	if !NewSecurePassword().CheckPasswordSecurity(password, false) {
+	if !securepassword.DefaultGenerator.CheckPasswordSecurity(password, false) {
 		t.Error("Password did not pass security test")
 	}
 
-	if NewSecurePassword().CheckPasswordSecurity(password, true) {
+	if securepassword.DefaultGenerator.CheckPasswordSecurity(password, true) {
 		t.Error("Password without special characters passed security test for passwords with special characters")
 	}
 
-	password, _ = NewSecurePassword().GeneratePassword(32, true)
+	password, _ = securepassword.DefaultGenerator.GeneratePassword(32, true)
 
 	if len(password) != 32 {
 		t.Error("Password did not match requested length")
 	}
 
-	if !NewSecurePassword().CheckPasswordSecurity(password, false) {
+	if !securepassword.DefaultGenerator.CheckPasswordSecurity(password, false) {
 		t.Error("Password did not pass security test for passwords without special characters")
 	}
 
-	if !NewSecurePassword().CheckPasswordSecurity(password, true) {
+	if !securepassword.DefaultGenerator.CheckPasswordSecurity(password, true) {
 		t.Error("Password without special characters did not security test for passwords with special characters")
 	}
 }
 
 func TestImpossiblePasswords(t *testing.T) {
 	for i := 0; i < 4; i++ {
-		_, err := NewSecurePassword().GeneratePassword(i, false)
-		if err != ErrLengthTooLow {
+		_, err := securepassword.DefaultGenerator.GeneratePassword(i, false)
+		if err != securepassword.ErrLengthTooLow {
 			t.Errorf("Password with a length of %d did not throw as ErrLengthTooLow error", i)
 		}
 	}
@@ -126,7 +129,7 @@ func TestBadCharacters(t *testing.T) {
 	badCharacters := []string{"I", "l", "0", "O", "B", "8"}
 
 	for i := 0; i < 500; i++ {
-		pwd, err := NewSecurePassword().GeneratePassword(20, false)
+		pwd, err := securepassword.DefaultGenerator.GeneratePassword(20, false)
 		if err != nil {
 			t.Errorf("An error occured: %s", err)
 		}
@@ -139,58 +142,119 @@ func TestBadCharacters(t *testing.T) {
 	}
 }
 
+func TestPartialCustomGenerator(t *testing.T) {
+	pwd := &securepassword.SecurePassword{
+		CharacterTables: map[string]string{
+			"numeric": "123456789",
+			"simple":  "abcdefghijklmnopqrstuvwxyz",
+			"special": "*-/",
+		},
+		BadCharacters: []string{"0", "O"},
+	}
+
+	p, err := pwd.GeneratePassword(20, true)
+
+	if err != nil {
+		t.Errorf("Custom generator had an error: %s", err)
+	}
+
+	if len(p) != 20 {
+		t.Errorf("Password did not match required length (20): %s", p)
+	}
+}
+
+func TestInvalidCustomGenerator(t *testing.T) {
+	pwd := &securepassword.SecurePassword{
+		CharacterTables: map[string]string{
+			"numeric": "123456789",
+			"simple":  "abcdefghijklmnopqrstuvwxyz",
+		},
+		BadCharacters: []string{"0", "O"},
+	}
+
+	p, err := pwd.GeneratePassword(20, true)
+
+	if err != securepassword.ErrGeneratorMissingFeatures {
+		t.Errorf("Generator should have thrown an error but didn't")
+	}
+
+	if len(p) != 0 {
+		t.Errorf("A password was generated with an invalid generator")
+	}
+}
+
 func BenchmarkGeneratePasswords8Char(b *testing.B) {
-	pwd := NewSecurePassword()
+	pwd := securepassword.DefaultGenerator
 	for i := 0; i < b.N; i++ {
 		pwd.GeneratePassword(8, false)
 	}
 }
 
 func BenchmarkGeneratePasswords8CharSpecial(b *testing.B) {
-	pwd := NewSecurePassword()
+	pwd := securepassword.DefaultGenerator
 	for i := 0; i < b.N; i++ {
 		pwd.GeneratePassword(8, true)
 	}
 }
 
 func BenchmarkGeneratePasswords16Char(b *testing.B) {
-	pwd := NewSecurePassword()
+	pwd := securepassword.DefaultGenerator
 	for i := 0; i < b.N; i++ {
 		pwd.GeneratePassword(16, false)
 	}
 }
 
 func BenchmarkGeneratePasswords16CharSpecial(b *testing.B) {
-	pwd := NewSecurePassword()
+	pwd := securepassword.DefaultGenerator
 	for i := 0; i < b.N; i++ {
 		pwd.GeneratePassword(16, true)
 	}
 }
 
 func BenchmarkGeneratePasswords32Char(b *testing.B) {
-	pwd := NewSecurePassword()
+	pwd := securepassword.DefaultGenerator
 	for i := 0; i < b.N; i++ {
 		pwd.GeneratePassword(32, false)
 	}
 }
 
 func BenchmarkGeneratePasswords32CharSpecial(b *testing.B) {
-	pwd := NewSecurePassword()
+	pwd := securepassword.DefaultGenerator
 	for i := 0; i < b.N; i++ {
 		pwd.GeneratePassword(32, true)
 	}
 }
 
 func BenchmarkGeneratePasswords128Char(b *testing.B) {
-	pwd := NewSecurePassword()
+	pwd := securepassword.DefaultGenerator
 	for i := 0; i < b.N; i++ {
 		pwd.GeneratePassword(128, false)
 	}
 }
 
 func BenchmarkGeneratePasswords128CharSpecial(b *testing.B) {
-	pwd := NewSecurePassword()
+	pwd := securepassword.DefaultGenerator
 	for i := 0; i < b.N; i++ {
 		pwd.GeneratePassword(128, true)
 	}
+}
+
+func ExampleGeneratePassword() {
+	pass, _ := securepassword.DefaultGenerator.GeneratePassword(20, true)
+	fmt.Println(pass)
+}
+
+func ExampleGeneratePassword_custom() {
+	pwd := &securepassword.SecurePassword{
+		CharacterTables: map[string]string{
+			"numeric": "123456789",
+			"simple":  "abcdefghijklmnopqrstuvwxyz",
+			"special": "*-/",
+		},
+		InsecurePattern: securepassword.DefaultGenerator.InsecurePattern,
+		BadCharacters:   []string{"0", "O"},
+	}
+
+	pass, _ := pwd.GeneratePassword(20, true)
+	fmt.Println(pass)
 }


### PR DESCRIPTION
This adds the requested feature of customized generators (#1). Though I'm not yet sure whether this is a good implementation yet. The only check done is whether all character sets are present but they are neither checked for length (so they may be empty strings) nor is there a check whether the insecure password patterns are present.

Given those two facts this generator is still called `securepassword` but may be used to create passwords not having/passing any security check:

Possible outcome:
- Numeric / alphabetic only passwords (`13846234`, `asfadhsdfg` - **insecure**)
- Passwords following a bad pattern (`123456` - **worst password ever**)
- Empty passwords (welcome to endless loop)

So it's to be discussed whether those checks should be enforced and also whether the character sets needs to match a certain rule (for example "contains 10 characters" which would weaken the passwords but not that much as keeping them empty)…

refs #1 