### PR TITLE
Makes generated passwords actionable again

### DIFF
--- a/alfred-workflow/exec.py
+++ b/alfred-workflow/exec.py
@@ -52,10 +52,12 @@ def main(wf):
 
     wf.add_item(title=result['password'],
                 subtitle="Press Cmd+C to copy",
-                arg=result['password'])
+                arg=result['password'],
+                valid=True)
     wf.add_item(title="Copy hashed versions",
                 subtitle="Press Cmd+C to copy",
-                arg="\n".join(hashed))
+                arg="\n".join(hashed),
+                valid=True)
     wf.send_feedback()
 
     return 0


### PR DESCRIPTION
I just updated to the latest version and notice the generated passwords were selectable anymore.

This makes the items actionable again. The `feedback.py` lib used in the old version defaulted items to actionable. However the `Workflow` lib used in the latest version does not.